### PR TITLE
Add aarch64 for macOS (for M series chip Macs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
             target: x86_64-apple-darwin
             file: libdsd_ghidra.dylib
 
+          - os: macos-latest
+            name: darwin-arm64
+            target: aarch64-apple-darwin
+            file: libdsd_ghidra.dylib
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             file: libdsd_ghidra.so
 
-          - os: macos-latest
+          - os: macos-13
             name: darwin-x86_64
             target: x86_64-apple-darwin
             file: libdsd_ghidra.dylib


### PR DESCRIPTION
Update the github action to build the aarch64 dylib in addition to the x86_64 one.