### PR TITLE
Bump ds-decomp and ds-rom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,47 @@
-name: Release dsd-ghidra
+name: Build
 
 on:
+  pull_request:
   workflow_dispatch:
 
+env:
+  RUSTFLAGS: -D warnings
+
 jobs:
-  build:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Rust workspace
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        run: cargo clippy
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Format
+        run: cargo fmt --all --check
+
+  build-shared-libs:
     strategy:
       matrix:
         include:
@@ -54,16 +91,14 @@ jobs:
           path: target/${{ matrix.target }}/release/${{ matrix.file }}
           if-no-files-found: error
 
-  publish:
+  build-extension:
     runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: write
+    needs: build-shared-libs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download artifact
+      - name: Download artifacts (shared libraries)
         uses: actions/download-artifact@v4
         with:
           path: ./dsd-ghidra/src/main/resources
@@ -88,10 +123,42 @@ jobs:
         run: |
           gradle --project-dir dsd-ghidra --info --stacktrace
 
+      - name: Get artifact filename
+        id: artifact_name
+        run: echo "name=$(basename dsd-ghidra/dist/ghidra_*_dsd-ghidra.zip)" >> $GITHUB_OUTPUT
+
+      - name: Delete artifacts (shared libraries)
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: "*"
+
+      - name: Upload artifact (Ghidra extension)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact_name.outputs.name }}
+          path: dsd-ghidra/dist/ghidra_*_dsd-ghidra.zip
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build-extension
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ghidra_*_dsd-ghidra.zip
+          path: artifacts
+
       - name: Upload release
         uses: softprops/action-gh-release@v2
         with:
-          files: dsd-ghidra/dist/ghidra_*_dsd-ghidra.zip
+          files: artifacts/**
           draft: true
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "dsd-ghidra"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cpp_demangle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "autocfg"
@@ -45,10 +90,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitfield-struct"
-version = "0.8.0"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de05f8756f1c68937349406d4632ae96ae35901019b5e59c508d9c38c64715fb"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitfield-struct"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -60,12 +111,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitreader"
@@ -86,19 +131,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.23.0"
+name = "bumpalo"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -137,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -181,24 +232,26 @@ dependencies = [
 
 [[package]]
 name = "ds-decomp"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57890a7e149915864e96b31a5eb1bc9a4a8db87a233c2c2a547e4f8022104de1"
+checksum = "76964657c13b20b009f8bd534a3a0dfb90a0c9ef37bb92b7c7c84427b2985772"
 dependencies = [
  "bytemuck",
  "ds-rom",
  "log",
  "serde",
- "serde_yml",
+ "serde-saphyr",
  "snafu",
+ "strum",
+ "strum_macros",
  "unarm",
 ]
 
 [[package]]
 name = "ds-rom"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c83565f49d5f2977904a3f70ff1b9d53ed81ddd46c4b0fffe880efdf334faf"
+checksum = "473d5a6494a1be90379bf6f346cce68ee36baa60a997eacf947071af82f973fe"
 dependencies = [
  "bitfield-struct",
  "bitreader",
@@ -209,7 +262,7 @@ dependencies = [
  "log",
  "rust-bitwriter",
  "serde",
- "serde_yml",
+ "serde-saphyr",
  "sha1",
  "snafu",
 ]
@@ -235,26 +288,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
+name = "encoding_rs_io"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
- "libc",
- "windows-sys",
+ "encoding_rs",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -286,16 +326,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -316,38 +364,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.7.0"
+name = "js-sys"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
- "equivalent",
- "hashbrown",
+ "once_cell",
+ "wasm-bindgen",
 ]
-
-[[package]]
-name = "itoa"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libyml"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -370,6 +400,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "num-traits"
@@ -401,7 +437,7 @@ version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -427,6 +463,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rust-bitwriter"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,23 +513,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustix"
-version = "0.38.42"
+name = "rustversion"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "saphyr-parser-bw"
+version = "0.0.611"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "67dec0c833db75dc98957956b303fe447ffc5eb13f2325ef4c2350f7f3aa69e3"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror",
+]
 
 [[package]]
 name = "serde"
@@ -470,6 +539,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fbdfe7a27a1b1633dfc0c4c8e65940b8d819c5ddb9cca48ebc3223b00c8b14"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom",
+ "nohash-hasher",
+ "num-traits",
+ "regex",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,35 +567,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.133"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "log",
- "memchr",
- "ryu",
- "serde",
- "serde_json",
- "tempfile",
 ]
 
 [[package]]
@@ -525,6 +585,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
@@ -549,6 +615,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,16 +644,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.14.0"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys",
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -591,18 +682,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "windows-targets",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -668,3 +810,35 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/dsd-ghidra/ghidra_scripts/SyncDsd.java
+++ b/dsd-ghidra/ghidra_scripts/SyncDsd.java
@@ -16,7 +16,10 @@ import ghidra.framework.model.Project;
 import ghidra.framework.model.ProjectData;
 import ghidra.framework.model.ProjectLocator;
 import ghidra.program.model.lang.Register;
-import ghidra.program.model.listing.*;
+import ghidra.program.model.listing.BookmarkManager;
+import ghidra.program.model.listing.BookmarkType;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.ProgramContext;
 import ghidra.program.model.mem.Memory;
 import ghidra.util.exception.CancelledException;
 import org.jetbrains.annotations.NotNull;
@@ -41,8 +44,7 @@ public class SyncDsd extends GhidraScript {
     }
 
     @Override
-    protected void run()
-    throws Exception {
+    protected void run() throws Exception {
         Memory memory = currentProgram.getMemory();
         ProgramContext programContext = currentProgram.getProgramContext();
         this.thumbRegister = programContext.getRegister("TMode");
@@ -50,7 +52,11 @@ public class SyncDsd extends GhidraScript {
 
         loadProperties();
 
-        DsdConfigChooser dsdConfigChooser = new DsdConfigChooser(null, "Begin sync", this.properties);
+        DsdConfigChooser dsdConfigChooser = new DsdConfigChooser(
+            null,
+            "Begin sync",
+            this.properties
+        );
         File file = dsdConfigChooser.getSelectedFile();
         dsdConfigChooser.dispose();
         if (dsdConfigChooser.wasCancelled()) {
@@ -103,13 +109,15 @@ public class SyncDsd extends GhidraScript {
         }
     }
 
-    private void saveProperties()
-    throws IOException {
+    private void saveProperties() throws IOException {
         File propertiesFile = getPropertiesFile();
-        this.properties.store(new FileOutputStream(propertiesFile), "Properties for the SyncDsd.java script");
+        this.properties.store(
+            new FileOutputStream(propertiesFile),
+            "Properties for the SyncDsd.java script"
+        );
     }
 
-    private void doSync(DsdSyncData dsdSyncData) {
+    private void doSync(DsdSyncData dsdSyncData) throws DsSection.Exception, DsModules.Exception {
         if (!dryRun) {
             this.removeBookmarks();
         }
@@ -135,10 +143,7 @@ public class SyncDsd extends GhidraScript {
         for (DsdSyncOverlay overlay : dsdSyncData.getArm9Overlays()) {
             DsModule dsModule = dsModules.getOverlay(overlay.id);
             if (dsModule == null) {
-                printerr(String.format(
-                    "No memory blocks for overlay %d",
-                    overlay.id
-                ));
+                printerr(String.format("No memory blocks for overlay %d", overlay.id));
                 return;
             }
             this.syncModule(overlay.module, dsModule);
@@ -158,14 +163,15 @@ public class SyncDsd extends GhidraScript {
         }
     }
 
-    private void syncModule(DsdSyncModule dsdSyncModule, @NotNull DsModule dsModule) {
+    private void syncModule(DsdSyncModule dsdSyncModule, @NotNull DsModule dsModule)
+        throws DsSection.Exception, DsModules.Exception {
         try {
             this.updateModule(dsdSyncModule, dsModule);
         } catch (Exception e) {
             printerr(String.format(
                 "Failed to update module %s, see error:\n%s",
                 dsModule.name,
-                e
+                getExceptionStackTrace(e)
             ));
             return;
         }
@@ -211,7 +217,7 @@ public class SyncDsd extends GhidraScript {
                     printerr(String.format(
                         "Failed to join module %s, see error:\n%s",
                         dsModule.name,
-                        e
+                        getExceptionStackTrace(e)
                     ));
                     return;
                 }
@@ -221,7 +227,7 @@ public class SyncDsd extends GhidraScript {
                     printerr(String.format(
                         "Failed to split module %s, see error:\n%s",
                         dsModule.name,
-                        e
+                        getExceptionStackTrace(e)
                     ));
                     return;
                 }
@@ -263,7 +269,7 @@ public class SyncDsd extends GhidraScript {
                 function.name.getString(),
                 function.start,
                 dsSection.getModule().name,
-                e
+                getExceptionStackTrace(e)
             ));
             return;
         }
@@ -282,7 +288,7 @@ public class SyncDsd extends GhidraScript {
                         syncFunction.symbolName.name,
                         syncFunction.start,
                         dsSection.getModule().name,
-                        e
+                        getExceptionStackTrace(e)
                     ));
                     return;
                 }
@@ -298,7 +304,7 @@ public class SyncDsd extends GhidraScript {
                         ghidraFunction.getName(),
                         syncFunction.start,
                         dsSection.getModule().name,
-                        e
+                        getExceptionStackTrace(e)
                     ));
                     return;
                 }
@@ -314,7 +320,7 @@ public class SyncDsd extends GhidraScript {
                     ghidraFunction.getName(),
                     syncFunction.start,
                     dsSection.getModule().name,
-                    e
+                    getExceptionStackTrace(e)
                 ));
                 return;
             }
@@ -334,7 +340,7 @@ public class SyncDsd extends GhidraScript {
                 dataSymbol.address,
                 dsSection.getName(),
                 dsSection.getModule().name,
-                e
+                getExceptionStackTrace(e)
             ));
             return;
         }
@@ -348,8 +354,7 @@ public class SyncDsd extends GhidraScript {
                 if (!dryRun) {
                     syncDataSymbol.deleteExistingLabels();
                 }
-                println("Updating data " + currentName + " at " + syncDataSymbol.address + " to name " +
-                    syncDataSymbol.symbolName.symbol);
+                println("Updating data " + currentName + " at " + syncDataSymbol.address + " to name " + syncDataSymbol.symbolName.symbol);
             } else {
                 return;
             }
@@ -367,14 +372,15 @@ public class SyncDsd extends GhidraScript {
                     syncDataSymbol.address,
                     dsSection.getName(),
                     dsSection.getModule().name,
-                    e
+                    getExceptionStackTrace(e)
                 ));
             }
             syncDataSymbol.defineData(this);
         }
     }
 
-    private void updateReferences(DsdSyncRelocation relocation, DsSection dsSection) {
+    private void updateReferences(DsdSyncRelocation relocation, DsSection dsSection)
+        throws DsSection.Exception, DsModules.Exception {
         SyncRelocation syncRelocation;
         try {
             syncRelocation = new SyncRelocation(currentProgram, dsSection, relocation);
@@ -384,7 +390,7 @@ public class SyncDsd extends GhidraScript {
                 relocation.from,
                 dsSection.getName(),
                 dsSection.getModule().name,
-                e
+                getExceptionStackTrace(e)
             ));
             return;
         }
@@ -409,10 +415,16 @@ public class SyncDsd extends GhidraScript {
                     relocation.from,
                     dsSection.getName(),
                     dsSection.getModule().name,
-                    e
+                    getExceptionStackTrace(e)
                 ));
                 return;
             }
         }
+    }
+
+    public static String getExceptionStackTrace(Exception e) {
+        StringWriter writer = new StringWriter();
+        e.printStackTrace(new PrintWriter(writer));
+        return writer.toString();
     }
 }

--- a/dsd-ghidra/ghidra_scripts/SyncDsd.java
+++ b/dsd-ghidra/ghidra_scripts/SyncDsd.java
@@ -379,8 +379,7 @@ public class SyncDsd extends GhidraScript {
         }
     }
 
-    private void updateReferences(DsdSyncRelocation relocation, DsSection dsSection)
-        throws DsSection.Exception, DsModules.Exception {
+    private void updateReferences(DsdSyncRelocation relocation, DsSection dsSection) {
         SyncRelocation syncRelocation;
         try {
             syncRelocation = new SyncRelocation(currentProgram, dsSection, relocation);
@@ -395,8 +394,9 @@ public class SyncDsd extends GhidraScript {
             return;
         }
 
-        if (syncRelocation.needsUpdate()) {
-            println("Updating references from " + syncRelocation.from);
+        String updateReason = syncRelocation.getUpdateReason();
+        if (updateReason != null) {
+            println("Updating references from " + syncRelocation.from + " : " + updateReason);
             if (!dryRun) {
                 syncRelocation.deleteExistingReferences();
             }

--- a/dsd-ghidra/src/main/java/dsdghidra/dsd/DsdRelocationKind.java
+++ b/dsd-ghidra/src/main/java/dsdghidra/dsd/DsdRelocationKind.java
@@ -5,12 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public enum DsdRelocationKind {
-    ArmCall,
-    ThumbCall,
-    ArmCallThumb,
-    ThumbCallArm,
-    ArmBranch,
-    Load;
+    ArmCall, ThumbCall, ArmCallThumb, ThumbCallArm, ArmBranch, Load, OverlayId, LinkTimeConst;
 
     public static final @NotNull DsdRelocationKind[] VALUES = DsdRelocationKind.values();
 

--- a/dsd-ghidra/src/main/java/dsdghidra/sync/SyncRelocation.java
+++ b/dsd-ghidra/src/main/java/dsdghidra/sync/SyncRelocation.java
@@ -11,6 +11,7 @@ import ghidra.program.model.symbol.ReferenceManager;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.program.model.util.CodeUnitInsertionException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SyncRelocation {
     public final @NotNull DsdSyncRelocation dsdRelocation;
@@ -28,7 +29,7 @@ public class SyncRelocation {
         this.program = program;
     }
 
-    public boolean needsUpdate() {
+    public @Nullable String getUpdateReason() {
         ReferenceManager referenceManager = program.getReferenceManager();
         Reference[] references = referenceManager.getReferencesFrom(from);
 
@@ -37,22 +38,33 @@ public class SyncRelocation {
             }
             case OverlayId, LinkTimeConst -> {
                 // Only used for linking, not relevant for Ghidra projects
-                return false;
+                return null;
             }
         }
 
         switch (dsdRelocation.getModule()) {
             case None -> {
-                return references.length > 0;
+                if (references.length > 0) {
+                    return "There are references at this address but the relocation points to no module";
+                }
+                return null;
             }
             case Overlays -> {
-                if (dsdRelocation.indices.len != references.length) {
-                    return true;
+                if (references.length != dsdRelocation.indices.len) {
+                    return String.format(
+                        "Currently has %d overlay relocations but should be %d",
+                        references.length,
+                        dsdRelocation.indices.len
+                    );
                 }
                 short[] overlays = dsdRelocation.indices.getArray();
                 for (Reference reference : references) {
                     if (reference.getToAddress().getOffset() != dsdRelocation.to) {
-                        return true;
+                        return String.format(
+                            "An overlay reference points to %08x but should be %08x",
+                            reference.getToAddress().getOffset(),
+                            dsdRelocation.to
+                        );
                     }
 
                     String addressSpaceName = reference.getToAddress().getAddressSpace().getName();
@@ -65,51 +77,104 @@ public class SyncRelocation {
                         }
                     }
                     if (!found) {
-                        return true;
+                        return "One or more overlays are missing from the reference list";
                     }
                 }
-                return false;
+                return null;
             }
             case Main -> {
                 if (references.length != 1) {
-                    return true;
+                    return String.format(
+                        "Currently has %d main module relocations but should be 1",
+                        references.length
+                    );
                 }
                 if (references[0].getToAddress().getOffset() != dsdRelocation.to) {
-                    return true;
+                    return String.format(
+                        "This main module reference points to %08x but should be %08x",
+                        references[0].getToAddress().getOffset(),
+                        dsdRelocation.to
+                    );
                 }
                 String addressSpaceName = references[0].getToAddress().getAddressSpace().getName();
-                return isMain(addressSpaceName);
+                if (!isMain(addressSpaceName)) {
+                    return String.format(
+                        "This reference points to %s but should point to the main module",
+                        addressSpaceName
+                    );
+                }
+                return null;
             }
             case Itcm -> {
                 if (references.length != 1) {
-                    return true;
+                    return String.format(
+                        "Currently has %d ITCM relocations but should be 1",
+                        references.length
+                    );
                 }
                 if (references[0].getToAddress().getOffset() != dsdRelocation.to) {
-                    return true;
+                    return String.format(
+                        "This ITCM reference points to %08x but should be %08x",
+                        references[0].getToAddress().getOffset(),
+                        dsdRelocation.to
+                    );
                 }
                 String addressSpaceName = references[0].getToAddress().getAddressSpace().getName();
-                return isItcm(addressSpaceName);
+                if (!isItcm(addressSpaceName)) {
+                    return String.format(
+                        "This reference points to %s but should point to the ITCM",
+                        addressSpaceName
+                    );
+                }
+                return null;
             }
             case Dtcm -> {
                 if (references.length != 1) {
-                    return true;
+                    return String.format(
+                        "Currently has %d DTCM relocations but should be 1",
+                        references.length
+                    );
                 }
                 if (references[0].getToAddress().getOffset() != dsdRelocation.to) {
-                    return true;
+                    return String.format(
+                        "This DTCM reference points to %08x but should be %08x",
+                        references[0].getToAddress().getOffset(),
+                        dsdRelocation.to
+                    );
                 }
                 String addressSpaceName = references[0].getToAddress().getAddressSpace().getName();
-                return isDtcm(addressSpaceName);
+                if (!isDtcm(addressSpaceName)) {
+                    return String.format(
+                        "This reference points to %s but should point to the DTCM",
+                        addressSpaceName
+                    );
+                }
+                return null;
             }
             case Autoload -> {
                 if (references.length != 1) {
-                    return true;
+                    return String.format(
+                        "Currently has %d autoload relocations but should be 1",
+                        references.length
+                    );
                 }
                 if (references[0].getToAddress().getOffset() != dsdRelocation.to) {
-                    return true;
+                    return String.format(
+                        "This autoload reference points to %08x but should be %08x",
+                        references[0].getToAddress().getOffset(),
+                        dsdRelocation.to
+                    );
                 }
                 String addressSpaceName = references[0].getToAddress().getAddressSpace().getName();
                 int autoloadIndex = dsdRelocation.indices.getArray()[0];
-                return parseAutoloadIndex(addressSpaceName) == autoloadIndex;
+                if (parseAutoloadIndex(addressSpaceName) != autoloadIndex) {
+                    return String.format(
+                        "This reference points to %s but should point to autoload %d",
+                        addressSpaceName,
+                        autoloadIndex
+                    );
+                }
+                return null;
             }
         }
         throw new MatchException("Unknown relocation type", null);
@@ -176,17 +241,19 @@ public class SyncRelocation {
     }
 
     private static boolean isMain(@NotNull String addressSpaceName) {
-        return addressSpaceName.equals("arm9_main") || addressSpaceName.equals("arm9_main.bss") || addressSpaceName.equals(
-            "ARM9_Main_Memory") || addressSpaceName.equals("ARM9_Main_Memory.bss");
+        return addressSpaceName.equals("ram") || addressSpaceName.equals("arm9_main") || addressSpaceName.equals(
+            "arm9_main.bss") || addressSpaceName.equals("ARM9_Main_Memory") || addressSpaceName.equals(
+            "ARM9_Main_Memory.bss");
     }
 
     private static boolean isItcm(@NotNull String addressSpaceName) {
-        return addressSpaceName.equals("itcm") || addressSpaceName.equals("ITCM");
+        return addressSpaceName.equals("ram") || addressSpaceName.equals("itcm") || addressSpaceName.equals(
+            "ITCM");
     }
 
     private static boolean isDtcm(@NotNull String addressSpaceName) {
-        return addressSpaceName.equals("dtcm") || addressSpaceName.equals("dtcm.bss") || addressSpaceName.equals(
-            "DTCM") || addressSpaceName.equals("DTCM.bss");
+        return addressSpaceName.equals("ram") || addressSpaceName.equals("dtcm") || addressSpaceName.equals(
+            "dtcm.bss") || addressSpaceName.equals("DTCM") || addressSpaceName.equals("DTCM.bss");
     }
 
     private static int parseAutoloadIndex(@NotNull String blockName) {

--- a/dsd-ghidra/src/main/java/dsdghidra/sync/SyncRelocation.java
+++ b/dsd-ghidra/src/main/java/dsdghidra/sync/SyncRelocation.java
@@ -17,8 +17,7 @@ public class SyncRelocation {
     public final @NotNull Address from;
     private final @NotNull Program program;
 
-    public SyncRelocation(
-        @NotNull Program program,
+    public SyncRelocation(@NotNull Program program,
         @NotNull DsSection dsSection,
         @NotNull DsdSyncRelocation dsdRelocation
     ) throws DsSection.Exception {
@@ -32,6 +31,15 @@ public class SyncRelocation {
     public boolean needsUpdate() {
         ReferenceManager referenceManager = program.getReferenceManager();
         Reference[] references = referenceManager.getReferencesFrom(from);
+
+        switch (dsdRelocation.getKind()) {
+            case ArmCall, ThumbCall, ArmCallThumb, ThumbCallArm, ArmBranch, Load -> {
+            }
+            case OverlayId, LinkTimeConst -> {
+                // Only used for linking, not relevant for Ghidra projects
+                return false;
+            }
+        }
 
         switch (dsdRelocation.getModule()) {
             case None -> {
@@ -117,7 +125,8 @@ public class SyncRelocation {
         referenceManager.removeAllReferencesFrom(from);
     }
 
-    public void addReferences(@NotNull FlatProgramAPI api, @NotNull DsModules dsModules) throws DsSection.Exception, DsModules.Exception {
+    public void addReferences(@NotNull FlatProgramAPI api, @NotNull DsModules dsModules)
+        throws DsSection.Exception, DsModules.Exception {
         switch (dsdRelocation.getModule()) {
             case None -> {
             }
@@ -139,8 +148,7 @@ public class SyncRelocation {
         }
     }
 
-    private void addReference(
-        @NotNull FlatProgramAPI api,
+    private void addReference(@NotNull FlatProgramAPI api,
         @NotNull DsModule toModule,
         boolean primary
     ) throws DsSection.Exception {
@@ -152,7 +160,13 @@ public class SyncRelocation {
 
         RefType refType = dsdRelocation.getKind().getRefType(dsdRelocation.conditional);
 
-        Reference reference = referenceManager.addMemoryReference(from, to, refType, SourceType.USER_DEFINED, 0);
+        Reference reference = referenceManager.addMemoryReference(
+            from,
+            to,
+            refType,
+            SourceType.USER_DEFINED,
+            0
+        );
         referenceManager.setPrimary(reference, primary);
 
         try {
@@ -162,22 +176,17 @@ public class SyncRelocation {
     }
 
     private static boolean isMain(@NotNull String addressSpaceName) {
-        return addressSpaceName.equals("arm9_main") ||
-            addressSpaceName.equals("arm9_main.bss") ||
-            addressSpaceName.equals("ARM9_Main_Memory") ||
-            addressSpaceName.equals("ARM9_Main_Memory.bss");
+        return addressSpaceName.equals("arm9_main") || addressSpaceName.equals("arm9_main.bss") || addressSpaceName.equals(
+            "ARM9_Main_Memory") || addressSpaceName.equals("ARM9_Main_Memory.bss");
     }
 
     private static boolean isItcm(@NotNull String addressSpaceName) {
-        return addressSpaceName.equals("itcm") ||
-            addressSpaceName.equals("ITCM");
+        return addressSpaceName.equals("itcm") || addressSpaceName.equals("ITCM");
     }
 
     private static boolean isDtcm(@NotNull String addressSpaceName) {
-        return addressSpaceName.equals("dtcm") ||
-            addressSpaceName.equals("dtcm.bss") ||
-            addressSpaceName.equals("DTCM") ||
-            addressSpaceName.equals("DTCM.bss");
+        return addressSpaceName.equals("dtcm") || addressSpaceName.equals("dtcm.bss") || addressSpaceName.equals(
+            "DTCM") || addressSpaceName.equals("DTCM.bss");
     }
 
     private static int parseAutoloadIndex(@NotNull String blockName) {

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsd-ghidra"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0"
 cpp_demangle = "0.4"
-ds-decomp = "0.10"
-ds-rom = "0.6"
+ds-decomp = "0.11"
+ds-rom = "0.7"
 unarm = "1.8"

--- a/native/src/sync.rs
+++ b/native/src/sync.rs
@@ -91,17 +91,15 @@ impl SafeDsdConfigData {
         let config = Config::from_file(path)?;
         let config_path = path.parent().unwrap();
 
-        let rom = Rom::load(
-            config_path.join(&config.rom_config),
-            RomLoadOptions {
-                key: None,
-                compress: false,
-                encrypt: false,
-                load_files: false,
-                load_banner: false,
-                load_header: false,
-            },
-        )?;
+        let rom = Rom::load(config_path.join(&config.rom_config), RomLoadOptions {
+            key: None,
+            compress: false,
+            encrypt: false,
+            load_files: false,
+            load_banner: false,
+            load_header: false,
+            load_multiboot_signature: false,
+        })?;
 
         let arm9 = SafeDsdSyncModule::new(ModuleKind::Arm9, config_path, &config.main_module, rom.arm9().code()?, false)?;
         let rom_autoloads = rom.arm9().autoloads()?;
@@ -182,17 +180,14 @@ impl SafeDsdSyncModule {
         let delinks = Delinks::from_file(root_path.join(&config_module.delinks), module_kind)?;
         let relocs = Relocations::from_file(root_path.join(&config_module.relocations))?;
 
-        let module = Module::new(
-            &mut symbol_map,
-            ModuleOptions {
-                kind: module_kind,
-                name: config_module.name.clone(),
-                relocations: relocs,
-                sections: delinks.sections,
-                code,
-                signed,
-            },
-        )?;
+        let module = Module::new(&mut symbol_map, ModuleOptions {
+            kind: module_kind,
+            name: config_module.name.clone(),
+            relocations: relocs,
+            sections: delinks.sections,
+            code,
+            signed,
+        })?;
 
         let sections =
             module.sections().iter().map(|section| SafeDsdSyncSection::new(section, &module, &symbol_map)).collect::<Vec<_>>();
@@ -299,7 +294,7 @@ impl SafeDsdSyncSection {
             let mut iter = symbol_map
                 .iter_by_address(section.address_range())
                 .filter_map(
-                    |symbol| {
+                    |(_, symbol)| {
                         if let SymbolKind::Data(sym_data) = symbol.kind {
                             Some((sym_data, symbol))
                         } else {
@@ -321,7 +316,7 @@ impl SafeDsdSyncSection {
         } else {
             symbol_map
                 .iter_by_address(section.address_range())
-                .filter_map(|symbol| {
+                .filter_map(|(_, symbol)| {
                     if let SymbolKind::Bss(sym_bss) = symbol.kind {
                         Some(SafeDsdSyncDataSymbol {
                             name: demangle(&symbol.name),
@@ -360,6 +355,7 @@ impl SafeDsdSyncSection {
                     }
                     RelocationKind::ThumbCall | RelocationKind::ThumbCallArm => false,
                     RelocationKind::Load | RelocationKind::OverlayId => false,
+                    RelocationKind::LinkTimeConst(_) => false,
                 };
                 SafeDsdSyncRelocation {
                     from: relocation.from_address(),

--- a/native/src/sync.rs
+++ b/native/src/sync.rs
@@ -79,7 +79,7 @@ pub struct SafeDsdSyncDataSymbol {
 pub struct SafeDsdSyncRelocation {
     from: u32,
     to: u32,
-    kind: RelocationKind,
+    kind: DsdRelocationKind,
     module: DsdSyncRelocationModule,
     indices: Vec<u16>,
     conditional: bool,
@@ -335,6 +335,16 @@ impl SafeDsdSyncSection {
             .relocations()
             .iter_range(section.address_range())
             .map(|(_, relocation)| {
+                let reloc_kind = match relocation.kind() {
+                    RelocationKind::ArmCall => DsdRelocationKind::ArmCall,
+                    RelocationKind::ThumbCall => DsdRelocationKind::ThumbCall,
+                    RelocationKind::ArmCallThumb => DsdRelocationKind::ArmCallThumb,
+                    RelocationKind::ThumbCallArm => DsdRelocationKind::ThumbCallArm,
+                    RelocationKind::ArmBranch => DsdRelocationKind::ArmBranch,
+                    RelocationKind::Load => DsdRelocationKind::Load,
+                    RelocationKind::OverlayId => DsdRelocationKind::OverlayId,
+                    RelocationKind::LinkTimeConst(_) => DsdRelocationKind::LinkTimeConst,
+                };
                 let (reloc_module, indices) = match relocation.module() {
                     RelocationModule::None => (DsdSyncRelocationModule::None, vec![]),
                     RelocationModule::Overlay { id } => (DsdSyncRelocationModule::Overlays, vec![*id]),
@@ -360,7 +370,7 @@ impl SafeDsdSyncSection {
                 SafeDsdSyncRelocation {
                     from: relocation.from_address(),
                     to: (relocation.to_address() as i32 + relocation.addend_value()) as u32,
-                    kind: relocation.kind(),
+                    kind: reloc_kind,
                     module: reloc_module,
                     indices,
                     conditional,
@@ -555,10 +565,23 @@ pub enum DsdSyncDataKind {
 pub struct DsdSyncRelocation {
     from: u32,
     to: u32,
-    kind: RelocationKind,
+    kind: DsdRelocationKind,
     module: DsdSyncRelocationModule,
     overlays: UnsafeList<u16>,
     conditional: Bool32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub enum DsdRelocationKind {
+    ArmCall,
+    ThumbCall,
+    ArmCallThumb,
+    ThumbCallArm,
+    ArmBranch,
+    Load,
+    OverlayId,
+    LinkTimeConst,
 }
 
 #[repr(C)]


### PR DESCRIPTION
ds-decomp and ds-rom have updated since the last release of dsd-ghidra, so they have now been set to the latest versions. This makes dsd-ghidra compatible with new features from ds-decomp.